### PR TITLE
Return new error code -6.

### DIFF
--- a/iotc-modustoolbox-sdk/src/iotconnect.c
+++ b/iotc-modustoolbox-sdk/src/iotconnect.c
@@ -314,7 +314,7 @@ int iotconnect_sdk_init() {
     cy_rslt_t ret_cy = iotc_mqtt_client_init(&mqtt_config);
     if (ret_cy) {
         printf("Failed to connect!\n");
-        ret = -6;
+        return -6;
     }
     return 0;
 


### PR DESCRIPTION
Untested / QA'd.

Code looked like it was meant to have a return, rather than an assignment.